### PR TITLE
MULE-12609: Every exported Mule package must contain api

### DIFF
--- a/src/main/java/org/mule/plugin/scripting/component/Scriptable.java
+++ b/src/main/java/org/mule/plugin/scripting/component/Scriptable.java
@@ -10,13 +10,12 @@ import static java.util.stream.Collectors.toMap;
 import static org.mule.runtime.api.i18n.I18nMessageFactory.createStaticMessage;
 import static org.mule.runtime.core.api.util.IOUtils.getResourceAsStream;
 import static org.mule.runtime.core.api.util.StringUtils.isBlank;
-import static org.mule.runtime.core.config.i18n.CoreMessages.cannotLoadFromClasspath;
-import static org.mule.runtime.core.config.i18n.CoreMessages.propertiesNotSet;
+import static org.mule.runtime.core.api.config.i18n.CoreMessages.cannotLoadFromClasspath;
+import static org.mule.runtime.core.api.config.i18n.CoreMessages.propertiesNotSet;
 
 import org.mule.runtime.api.lifecycle.Initialisable;
 import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.api.message.Message;
-import org.mule.runtime.core.DefaultMuleEventContext;
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.MuleContext;
 import org.mule.runtime.core.api.construct.FlowConstruct;

--- a/src/test/java/org/mule/plugin/scripting/config/ScriptingConfigErrorTestCase.java
+++ b/src/test/java/org/mule/plugin/scripting/config/ScriptingConfigErrorTestCase.java
@@ -8,7 +8,7 @@ package org.mule.plugin.scripting.config;
 
 import org.mule.runtime.core.api.config.ConfigurationException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
-import org.mule.runtime.core.context.DefaultMuleContextFactory;
+import org.mule.runtime.core.api.context.DefaultMuleContextFactory;
 import org.mule.tck.junit4.AbstractMuleTestCase;
 
 import org.junit.Test;


### PR DESCRIPTION
_ Moving classes from org.mule.runtime.core.execution to api/internal
_ Moving classes from org.mule.runtime.core.notification to api/internal
_ Moving more classes from org.mule.runtime.core.management.stats to api/internal
_ Moving more classes from org.mule.runtime.core.config to api/internal