### PR TITLE
MULE-12903: Every exported Mule package must contain api (part2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
         <dependency>
             <groupId>org.mule.tests.plugin</groupId>
             <artifactId>mule-tests-component-plugin</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
+            <version>${mule.runtime.version}</version>
             <classifier>mule-plugin</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,13 @@
             <version>${mule.runtime.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mule.tests.plugin</groupId>
+            <artifactId>mule-tests-component-plugin</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
+            <classifier>mule-plugin</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
MULE-10370: Remove custom-exception-strategy element

_ Moving classes from org.mule.runtime.core.extension to api/internal
_ Temporarily exporting org.mule.runtime.core.internal.extension (because MULE-12427)
_ Adding test:exception-strategy for tests to replace mule:custom-exception-strategy
_ Removing mule:custom-exception-strategy element