### PR TITLE
MULE-13045: Avoid passing the FlowConstruct around just to get the name of the flow

### DIFF
--- a/src/main/java/org/mule/plugin/scripting/component/ScriptProcessor.java
+++ b/src/main/java/org/mule/plugin/scripting/component/ScriptProcessor.java
@@ -14,8 +14,6 @@ import org.mule.runtime.api.message.Message;
 import org.mule.runtime.core.api.DefaultMuleException;
 import org.mule.runtime.core.api.Event;
 import org.mule.runtime.core.api.MuleContext;
-import org.mule.runtime.core.api.construct.FlowConstruct;
-import org.mule.runtime.core.api.construct.FlowConstructAware;
 import org.mule.runtime.core.api.context.MuleContextAware;
 import org.mule.runtime.core.api.lifecycle.LifecycleUtils;
 import org.mule.runtime.core.api.processor.AbstractProcessor;
@@ -29,11 +27,10 @@ import org.slf4j.LoggerFactory;
  * A Script service backed by a JSR-223 compliant script engine such as Groovy, JavaScript, or Rhino.
  */
 public class ScriptProcessor extends AbstractProcessor
-    implements Initialisable, Disposable, MuleContextAware, FlowConstructAware {
+    implements Initialisable, Disposable, MuleContextAware {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ScriptProcessor.class);
 
-  private FlowConstruct flowConstruct;
   private MuleContext muleContext;
   private Scriptable script;
 
@@ -54,7 +51,7 @@ public class ScriptProcessor extends AbstractProcessor
     // Set up initial script variables.
     Bindings bindings = script.getScriptEngine().createBindings();
     putBindings(bindings);
-    script.populateBindings(bindings, flowConstruct, event, eventBuilder);
+    script.populateBindings(bindings, getLocation(), event, eventBuilder);
     try {
       final Object result = script.runScript(bindings);
       if (result instanceof Message) {
@@ -87,11 +84,6 @@ public class ScriptProcessor extends AbstractProcessor
   @Override
   public void setMuleContext(MuleContext context) {
     this.muleContext = context;
-  }
-
-  @Override
-  public void setFlowConstruct(FlowConstruct flowConstruct) {
-    this.flowConstruct = flowConstruct;
   }
 
 }

--- a/src/main/java/org/mule/plugin/scripting/component/Scriptable.java
+++ b/src/main/java/org/mule/plugin/scripting/component/Scriptable.java
@@ -12,6 +12,7 @@ import static org.mule.runtime.core.api.config.i18n.CoreMessages.cannotLoadFromC
 import static org.mule.runtime.core.api.config.i18n.CoreMessages.propertiesNotSet;
 import static org.mule.runtime.core.api.util.IOUtils.getResourceAsStream;
 import static org.mule.runtime.core.api.util.StringUtils.isBlank;
+import static org.mule.runtime.dsl.api.component.config.ComponentLocationUtils.getFlowNameFrom;
 
 import org.mule.runtime.api.component.location.ComponentLocation;
 import org.mule.runtime.api.lifecycle.Initialisable;
@@ -203,7 +204,7 @@ public class Scriptable implements Initialisable, MuleContextAware {
     populateMessageBindings(bindings, event, eventBuilder);
 
     bindings.put(BINDING_EVENT, event);
-    bindings.put(BINDING_FLOW, location.getParts().get(0).getPartPath());
+    bindings.put(BINDING_FLOW, getFlowNameFrom(location));
   }
 
   protected void populateMessageBindings(Bindings bindings, Event event, Event.Builder eventBuilder) {

--- a/src/main/java/org/mule/plugin/scripting/transformer/ScriptTransformer.java
+++ b/src/main/java/org/mule/plugin/scripting/transformer/ScriptTransformer.java
@@ -9,8 +9,6 @@ package org.mule.plugin.scripting.transformer;
 import org.mule.plugin.scripting.component.Scriptable;
 import org.mule.runtime.api.lifecycle.InitialisationException;
 import org.mule.runtime.core.api.Event;
-import org.mule.runtime.core.api.construct.FlowConstruct;
-import org.mule.runtime.core.api.construct.FlowConstructAware;
 import org.mule.runtime.core.api.lifecycle.LifecycleUtils;
 import org.mule.runtime.core.api.transformer.TransformerException;
 import org.mule.runtime.core.transformer.AbstractMessageTransformer;
@@ -26,11 +24,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Runs a script to perform transformation on an object.
  */
-public class ScriptTransformer extends AbstractMessageTransformer implements FlowConstructAware {
+public class ScriptTransformer extends AbstractMessageTransformer {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ScriptTransformer.class);
-
-  private FlowConstruct flowConstruct;
 
   private Scriptable script;
 
@@ -49,7 +45,7 @@ public class ScriptTransformer extends AbstractMessageTransformer implements Flo
   @Override
   public Object transformMessage(Event event, Charset outputEncoding) throws TransformerException {
     Bindings bindings = script.getScriptEngine().createBindings();
-    script.populateBindings(bindings, flowConstruct, event, Event.builder(event));
+    script.populateBindings(bindings, getLocation(), event, Event.builder(event));
     try {
       return script.runScript(bindings);
     } catch (ScriptException e) {
@@ -65,10 +61,5 @@ public class ScriptTransformer extends AbstractMessageTransformer implements Flo
 
   public void setScript(Scriptable script) {
     this.script = script;
-  }
-
-  @Override
-  public void setFlowConstruct(FlowConstruct flowConstruct) {
-    this.flowConstruct = flowConstruct;
   }
 }

--- a/src/test/java/org/mule/plugin/scripting/transformer/GroovyScriptTransformerTestCase.java
+++ b/src/test/java/org/mule/plugin/scripting/transformer/GroovyScriptTransformerTestCase.java
@@ -6,6 +6,10 @@
  */
 package org.mule.plugin.scripting.transformer;
 
+import static java.util.Collections.singletonMap;
+import static org.mule.runtime.api.meta.AbstractAnnotatedObject.LOCATION_KEY;
+import static org.mule.runtime.dsl.api.component.config.DefaultComponentLocation.fromSingleComponent;
+
 import org.mule.plugin.scripting.component.Scriptable;
 import org.mule.runtime.core.api.transformer.Transformer;
 import org.mule.tck.core.transformer.AbstractTransformerTestCase;
@@ -29,6 +33,7 @@ public class GroovyScriptTransformerTestCase extends AbstractTransformerTestCase
 
     ScriptTransformer transformer = new ScriptTransformer();
     transformer.setName("StringToList");
+    transformer.setAnnotations(singletonMap(LOCATION_KEY, fromSingleComponent("flow")));
     transformer.setMuleContext(muleContext);
     transformer.setScript(script);
     transformer.initialise();
@@ -44,6 +49,7 @@ public class GroovyScriptTransformerTestCase extends AbstractTransformerTestCase
 
     ScriptTransformer transformer = new ScriptTransformer();
     transformer.setName("ListToString");
+    transformer.setAnnotations(singletonMap(LOCATION_KEY, fromSingleComponent("flow")));
     transformer.setMuleContext(muleContext);
     transformer.setScript(script);
     transformer.initialise();

--- a/src/test/resources/groovy-component-config-flow.xml
+++ b/src/test/resources/groovy-component-config-flow.xml
@@ -45,7 +45,7 @@
     <flow name="inlineScriptMutateVariable">
         <script:component>
             <script:script engine="groovy">
-                flowVars['foo'] = 'bar-mutated'
+                vars['foo'] = 'bar-mutated'
              </script:script>
         </script:component>
         <test:assert expression="#[mel:flowVars.foo == 'bar-mutated']"/>
@@ -54,7 +54,7 @@
     <flow name="inlineScriptAddVariable">
         <script:component>
             <script:script engine="groovy">
-                flowVars['foo'] = 'bar'
+                vars['foo'] = 'bar'
              </script:script>
         </script:component>
         <test:assert expression="#[mel:flowVars.foo == 'bar']"/>
@@ -63,7 +63,7 @@
     <flow name="inlineScriptMutateVariablesMap">
         <script:component>
             <script:script engine="groovy">
-                flowVars = new HashMap()              
+                vars = new HashMap()              
              </script:script>
         </script:component>
         <test:assert expression="#[mel:flowVars.foo == 'bar']"/>


### PR DESCRIPTION
* Remove `FlowConstruct` attributes and `FlowConstructAware` implementations where possible
* Use `ComponentLocation` instead of `FlowConstruct` to get the name of the flow
* Change `flowVars` binding to `vars`