### PR TITLE
MULE-13132: Add support to access privileged API class from test case

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,12 @@
             <classifier>mule-plugin</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mule.tests</groupId>
+            <artifactId>mule-tests-model</artifactId>
+            <version>${mule.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/org/mule/test/plugin/scripting/AbstractScriptingFunctionalTestCase.java
+++ b/src/test/java/org/mule/test/plugin/scripting/AbstractScriptingFunctionalTestCase.java
@@ -10,7 +10,7 @@ package org.mule.test.plugin.scripting;
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
 import org.mule.test.runner.ArtifactClassLoaderRunnerConfig;
 
-@ArtifactClassLoaderRunnerConfig(sharedRuntimeLibs = {"org.mule.tests:mule-tests-functional", "org.mule.tests:mule-tests-unit"})
+@ArtifactClassLoaderRunnerConfig(applicationSharedRuntimeLibs = {"org.mule.tests:mule-tests-model"})
 public abstract class AbstractScriptingFunctionalTestCase extends MuleArtifactFunctionalTestCase {
 
 }

--- a/src/test/java/org/mule/test/plugin/scripting/GroovyScriptFlowFunctionalTestCase.java
+++ b/src/test/java/org/mule/test/plugin/scripting/GroovyScriptFlowFunctionalTestCase.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
-
 import org.mule.functional.api.component.TestConnectorQueueHandler;
 import org.mule.runtime.api.message.Message;
 import org.mule.runtime.api.metadata.MediaType;


### PR DESCRIPTION
_ Adding a test-runner plugin to contain test code and access privileged APIs
_ Application's context is created using the application classloader
_ Test is executed using test runner classloader
_ Adding runner configuration attribute to set application libraries (not visible to plugins)
_ Adding runner configuration attribute to set exported libraries from the test runner
_ Extracting mule-test-model artifact form mule-test-unit to contain all the classes that are used from different plugins and needs to be shared from the application
_ Enabling defining mule modules with privileged exported packages but no privileges artifacts