### PR TITLE
W-14447114 - added Graal.js to engines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <jython.version>2.7.3</jython.version>
         <groovy.version>3.0.19</groovy.version>
         <jruby.version>9.3.8.0</jruby.version>
+        <graal.version>22.0.0</graal.version>
         <project.reactor.version>3.4.23</project.reactor.version>
         <file.connector.version>2.0.0-SNAPSHOT</file.connector.version>
         <mtf.tools.version>1.2.0-SNAPSHOT</mtf.tools.version>
@@ -112,12 +113,12 @@
         <dependency>
             <groupId>org.graalvm.js</groupId>
             <artifactId>js</artifactId>
-            <version>22.0.0</version>
+            <version>${graal.version}</version>
         </dependency>
         <dependency>
             <groupId>org.graalvm.js</groupId>
             <artifactId>js-scriptengine</artifactId>
-            <version>22.0.0</version>
+            <version>${graal.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -14,15 +14,15 @@
     <name>Scripting Module</name>
     <description>Support for embedding scripts inside Mule artifacts</description>
     <properties>
-        <munit.extensions.maven.plugin.version>1.1.3</munit.extensions.maven.plugin.version>
-        <munit.version>2.3.15</munit.version>
+        <munit.extensions.maven.plugin.version>1.2.0-SNAPSHOT</munit.extensions.maven.plugin.version>
+        <munit.version>3.1.0-SNAPSHOT</munit.version>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
         <jython.version>2.7.3</jython.version>
         <groovy.version>3.0.19</groovy.version>
         <jruby.version>9.3.8.0</jruby.version>
         <project.reactor.version>3.4.23</project.reactor.version>
-        <file.connector.version>1.5.1</file.connector.version>
-        <mtf.tools.version>1.1.2</mtf.tools.version>
+        <file.connector.version>2.0.0-SNAPSHOT</file.connector.version>
+        <mtf.tools.version>1.2.0-SNAPSHOT</mtf.tools.version>
         <jacoco.version>0.8.10</jacoco.version>
         <mtf.javaopts></mtf.javaopts>
         <mulesoftLicenseVersion>1.4.0</mulesoftLicenseVersion>
@@ -108,6 +108,16 @@
             <artifactId>commons-lang3</artifactId>
             <version>${commons.lang.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js</artifactId>
+            <version>22.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js-scriptengine</artifactId>
+            <version>22.0.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/org/mule/plugin/scripting/component/ScriptRunner.java
+++ b/src/main/java/org/mule/plugin/scripting/component/ScriptRunner.java
@@ -58,6 +58,7 @@ public class ScriptRunner {
   private static final String REGISTRY = "registry";
   private static final String ECMA_SCRIPT_ENGINE = "ECMAScript";
   private static final String NASHORN_ENGINE = "Nashorn";
+  private static final String GRAAL_ENGINE = "graal.js";
 
   private String engineName;
   private String scriptBody;
@@ -85,10 +86,10 @@ public class ScriptRunner {
 
     scriptEngine = createScriptEngineByName(engineName);
 
-    if (scriptEngine == null && ECMA_SCRIPT_ENGINE.equalsIgnoreCase(engineName)) {
-      scriptEngine = createScriptEngineByName(NASHORN_ENGINE);
-      LOGGER.warn("The " + ECMA_SCRIPT_ENGINE + " Scripting Engine name was not found. The Scripting Engine defaulted to "
-          + NASHORN_ENGINE);
+    if (scriptEngine == null && NASHORN_ENGINE.equalsIgnoreCase(engineName)) {
+      scriptEngine = createScriptEngineByName(GRAAL_ENGINE);
+      LOGGER.warn("The " + NASHORN_ENGINE
+          + " Scripting Engine name was not found. The Scripting Engine defaulted to " + GRAAL_ENGINE);
     }
 
     if (scriptEngine == null) {

--- a/src/test/munit/scripting-engines-test-cases.xml
+++ b/src/test/munit/scripting-engines-test-cases.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:scripting="http://www.mulesoft.org/schema/mule/scripting"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools" xmlns="http://www.mulesoft.org/schema/mule/core"
+      xsi:schemaLocation="
+		http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+		http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+		http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mule/scripting/current/mule-scripting.xsd">
+
+    <munit:config name="nashorn-script-test-case.xml" />
+
+    <munit:test name="NashornScriptTest">
+        <munit:execution >
+            <flow-ref name="nashorn"/>
+        </munit:execution>
+        <munit:validation >
+            <munit-tools:assert-equals actual="#[payload]" expected="hello world"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="EcmaScriptTest">
+        <munit:execution >
+            <flow-ref name="ecma"/>
+        </munit:execution>
+        <munit:validation >
+            <munit-tools:assert-equals actual="#[payload]" expected="hello world"/>
+        </munit:validation>
+    </munit:test>
+
+
+    <munit:test name="GraalScriptTest">
+        <munit:execution >
+            <flow-ref name="graal"/>
+        </munit:execution>
+        <munit:validation >
+            <munit-tools:assert-equals actual="#[payload]" expected="hello world"/>
+        </munit:validation>
+    </munit:test>
+
+    <flow name="nashorn">
+        <scripting:execute engine="Nashorn">
+            <scripting:code><![CDATA[tempPayload = "hello"; var world = " world"; tempPayload = tempPayload + world]]></scripting:code>
+        </scripting:execute>
+    </flow>
+
+    <flow name="ecma">
+        <scripting:execute engine="ECMAScript">
+            <scripting:code><![CDATA[tempPayload = "hello"; var world = " world"; tempPayload = tempPayload + world]]></scripting:code>
+        </scripting:execute>
+    </flow>
+
+    <flow name="graal">
+        <scripting:execute engine="graal.js">
+            <scripting:code><![CDATA[tempPayload = "hello"; var world = " world"; tempPayload = tempPayload + world]]></scripting:code>
+        </scripting:execute>
+    </flow>
+
+
+</mule>

--- a/src/test/munit/scripting-engines-test-cases.xml
+++ b/src/test/munit/scripting-engines-test-cases.xml
@@ -29,8 +29,6 @@ http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mul
         </munit:parameterizations>
     </munit:config>
 
-
-
     <munit:test name="testJavascriptScripting">
         <munit:execution >
             <scripting:execute engine="${engine}">
@@ -41,56 +39,5 @@ http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mul
             <munit-tools:assert-equals actual="#[payload]" expected="hello world"/>
         </munit:validation>
     </munit:test>
-
-
-
-<!--
-
-    <munit:test name="NashornScriptTest">
-        <munit:execution >
-            <flow-ref name="nashorn"/>
-        </munit:execution>
-        <munit:validation >
-            <munit-tools:assert-equals actual="#[payload]" expected="hello world"/>
-        </munit:validation>
-    </munit:test>
-
-    <munit:test name="EcmaScriptTest">
-        <munit:execution >
-            <flow-ref name="ecma"/>
-        </munit:execution>
-        <munit:validation >
-            <munit-tools:assert-equals actual="#[payload]" expected="hello world"/>
-        </munit:validation>
-    </munit:test>
-
-
-    <munit:test name="GraalScriptTest">
-        <munit:execution >
-            <flow-ref name="graal"/>
-        </munit:execution>
-        <munit:validation >
-            <munit-tools:assert-equals actual="#[payload]" expected="hello world"/>
-        </munit:validation>
-    </munit:test>
-
-    <flow name="nashorn">
-        <scripting:execute engine="Nashorn">
-            <scripting:code><![CDATA[tempPayload = "hello"; var world = " world"; tempPayload = tempPayload + world]]></scripting:code>
-        </scripting:execute>
-    </flow>
-
-    <flow name="ecma">
-        <scripting:execute engine="ECMAScript">
-            <scripting:code><![CDATA[tempPayload = "hello"; var world = " world"; tempPayload = tempPayload + world]]></scripting:code>
-        </scripting:execute>
-    </flow>
-
-    <flow name="graal">
-        <scripting:execute engine="graal.js">
-            <scripting:code><![CDATA[tempPayload = "hello"; var world = " world"; tempPayload = tempPayload + world]]></scripting:code>
-        </scripting:execute>
-    </flow>-->
-
 
 </mule>

--- a/src/test/munit/scripting-engines-test-cases.xml
+++ b/src/test/munit/scripting-engines-test-cases.xml
@@ -9,7 +9,42 @@
 		http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
 http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mule/scripting/current/mule-scripting.xsd">
 
-    <munit:config name="nashorn-script-test-case.xml" />
+    <munit:config name="scripting-engines-test-case.xml">
+        <munit:parameterizations>
+            <munit:parameterization name="NashornScriptTest">
+                <munit:parameters>
+                    <munit:parameter propertyName="engine" value="Nashorn"/>
+                </munit:parameters>
+            </munit:parameterization>
+            <munit:parameterization name="EcmaScriptTest">
+                <munit:parameters>
+                    <munit:parameter propertyName="engine" value="ECMAScript"/>
+                </munit:parameters>
+            </munit:parameterization>
+            <munit:parameterization name="GraalScriptTest">
+                <munit:parameters>
+                    <munit:parameter propertyName="engine" value="graal.js"/>
+                </munit:parameters>
+            </munit:parameterization>
+        </munit:parameterizations>
+    </munit:config>
+
+
+
+    <munit:test name="testJavascriptScripting">
+        <munit:execution >
+            <scripting:execute engine="${engine}">
+                <scripting:code><![CDATA[tempPayload = "hello"; var world = " world"; tempPayload = tempPayload + world]]></scripting:code>
+            </scripting:execute>
+        </munit:execution>
+        <munit:validation >
+            <munit-tools:assert-equals actual="#[payload]" expected="hello world"/>
+        </munit:validation>
+    </munit:test>
+
+
+
+<!--
 
     <munit:test name="NashornScriptTest">
         <munit:execution >
@@ -55,7 +90,7 @@ http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mul
         <scripting:execute engine="graal.js">
             <scripting:code><![CDATA[tempPayload = "hello"; var world = " world"; tempPayload = tempPayload + world]]></scripting:code>
         </scripting:execute>
-    </flow>
+    </flow>-->
 
 
 </mule>


### PR DESCRIPTION
I added Graal as a compile dependency. 
Since Nashorn is not included anymore after Java 15 then , when Nashorn is null it uses Graal for scripting. 
I added tests to cover Nashorn, Graal and Ecma. 