### PR TITLE
W-15294671: Remove ugly hack that override JAVA_OPTIONS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <description>Support for embedding scripts inside Mule artifacts</description>
     <properties>
         <munit.extensions.maven.plugin.version>1.2.0</munit.extensions.maven.plugin.version>
-        <munit.version>3.1.0-rc3</munit.version>
+        <munit.version>3.1.0</munit.version>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
         <jython.version>2.7.3</jython.version>
         <groovy.version>3.0.19</groovy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
         <file.connector.version>1.5.2</file.connector.version>
         <mtf.tools.version>1.2.0-rc1</mtf.tools.version>
         <jacoco.version>0.8.10</jacoco.version>
-        <mtf.javaopts></mtf.javaopts>
         <mulesoftLicenseVersion>1.4.0</mulesoftLicenseVersion>
         <license.maven.plugin.version>4.2</license.maven.plugin.version>
         <licensePath>LICENSE_HEADER_CPAL.txt</licensePath>
@@ -209,11 +208,6 @@
                             -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${session.executionRootDirectory}/target/jacoco-munit.exec
                         </argLine>
                     </argLines>
-                    <environmentVariables>
-                        <!-- Toggles the JDK17 style flag -->
-                        <!-- ugly hack -->
-                        <_JAVA_OPTIONS>-XX:+PrintCommandLineFlags ${mtf.javaopts}</_JAVA_OPTIONS>
-                    </environmentVariables>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <name>Scripting Module</name>
     <description>Support for embedding scripts inside Mule artifacts</description>
     <properties>
-        <munit.extensions.maven.plugin.version>1.2.0-rc2</munit.extensions.maven.plugin.version>
+        <munit.extensions.maven.plugin.version>1.2.0</munit.extensions.maven.plugin.version>
         <munit.version>3.1.0-rc3</munit.version>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
         <jython.version>2.7.3</jython.version>


### PR DESCRIPTION
I've removed an unsightly hack that we previously employed for executing MTF tests on Java 11, using flags to mimic Java 17 behavior. This hack overrides JAVA_OPTIONS, rendering it incompatible with the FIPS Validation Pipeline.